### PR TITLE
fix: category optional parameter

### DIFF
--- a/packages/askar-shared/src/askar/Askar.ts
+++ b/packages/askar-shared/src/askar/Askar.ts
@@ -207,7 +207,7 @@ export type ScanFreeOptions = { scanHandle: ScanHandle }
 export type ScanNextOptions = { scanHandle: ScanHandle }
 export type ScanStartOptions = {
   storeHandle: StoreHandle
-  category: string
+  category?: string
   profile?: string
   tagFilter?: Record<string, unknown>
   offset?: number


### PR DESCRIPTION
### Summary

- `category` as optional parameter in scan method