### PR TITLE
fix: askar release with example

### DIFF
--- a/examples/askar-react-native-example/package.json
+++ b/examples/askar-react-native-example/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@openwallet-foundation/askar-react-native-example",
-  "version": "1.0.0",
+  "name": "askar-react-native-example",
+  "version": "0.0.0",
   "private": true,
   "main": "./src/index.js",
   "scripts": {

--- a/packages/askar-nodejs/package.json
+++ b/packages/askar-nodejs/package.json
@@ -15,7 +15,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "files": ["build", "scripts", "../../LICENSE"],
+  "files": ["build", "scripts"],
   "scripts": {
     "types:check": "pnpm compile --noEmit",
     "build": "pnpm clean && pnpm compile",

--- a/packages/askar-shared/package.json
+++ b/packages/askar-shared/package.json
@@ -16,7 +16,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "files": ["build", "../../LICENSE"],
+  "files": ["build"],
   "scripts": {
     "types:check": "pnpm compile --noEmit",
     "build": "pnpm clean && pnpm compile",


### PR DESCRIPTION
there were errors with the `[../../LICENSE]` path, and the package name of the example app was causing issues.