### PR TITLE
fix(react-native): wrapper page alignment

### DIFF
--- a/packages/askar-react-native/android/build.gradle
+++ b/packages/askar-react-native/android/build.gradle
@@ -91,7 +91,8 @@ android {
             abiFilters 'x86', 'x86_64', 'armeabi-v7a', 'arm64-v8a'
             arguments "-DANDROID_STL=c++_shared",
                       "-DREACT_NATIVE_VERSION=${REACT_NATIVE_VERSION}",
-                      "-DNODE_MODULES_DIR=${nodeModules}"
+                      "-DNODE_MODULES_DIR=${nodeModules}",
+                      "-DANDROID_SUPPORT_FLEXIBLE_PAGE_SIZES=ON"
         }
     }
     


### PR DESCRIPTION
And yet another issue with Android 16KB page support: it seems that we had fixed native library, but were still compiling RN wrapper shared library with older page size. With this change, I ran [ELF alignment checker script](https://cs.android.com/android/platform/superproject/main/+/main:system/extras/tools/check_elf_alignment.sh) with my APK and both libraries were OK.

Hopefully this is the last fix until we can have fully Android 15 compatible wrappers.