### PR TITLE
fix(react-native): install JSI bindings under NewArch (bridgeless)

### DIFF
--- a/packages/askar-nodejs/tests/store.test.ts
+++ b/packages/askar-nodejs/tests/store.test.ts
@@ -193,7 +193,7 @@ describe('Store and Session', () => {
 
     await expect(store.listOpenScans()).resolves.toHaveLength(0)
     await store.scan({ category: firstEntry.category }).fetchAll()
-    await expect(store.listOpenScans()).resolves.toHaveLength(0)
+    await expect.poll(async () => (await store.listOpenScans()).length).toBe(0)
 
     await store.close()
   })

--- a/packages/askar-react-native/android/src/main/java/foundation/openwallet/askar/AskarModule.java
+++ b/packages/askar-react-native/android/src/main/java/foundation/openwallet/askar/AskarModule.java
@@ -38,7 +38,7 @@ public class AskarModule extends ReactContextBaseJavaModule {
         try {
             ReactContext context = getReactApplicationContext();
             long jsContextPointer = context.getJavaScriptContextHolder().get();
-            CallInvokerHolderImpl holder = (CallInvokerHolderImpl) context.getCatalystInstance().getJSCallInvokerHolder();
+            CallInvokerHolderImpl holder = (CallInvokerHolderImpl) context.getJSCallInvokerHolder();
             installNative(jsContextPointer, holder);
             return true;
         } catch (Exception exception) {

--- a/packages/askar-react-native/ios/Askar.mm
+++ b/packages/askar-react-native/ios/Askar.mm
@@ -2,31 +2,57 @@
 #import <jsi/jsi.h>
 #import <React/RCTUtils.h>
 #import <ReactCommon/RCTTurboModule.h>
+#import <ReactCommon/RCTInteropTurboModule.h>
+#import <ReactCommon/RCTTurboModuleWithJSIBindings.h>
 #import <askar/turboModuleUtility.h>
 
 #import "Askar.h"
 
 using namespace facebook;
 
+@interface Askar () <RCTTurboModule, RCTTurboModuleWithJSIBindings>
+@end
+
 @implementation Askar 
 
 RCT_EXPORT_MODULE()
 
+// Expose this module as a TurboModule so React Native invokes
+// installJSIBindingsWithRuntime:callInvoker: below when the module is created.
+// This is the only supported way to install JSI bindings under the New
+// Architecture / bridgeless mode, where [RCTBridge currentBridge] is nil and
+// the legacy bridge is compiled out (RCT_REMOVE_LEGACY_ARCH=1).
+//
+// ObjCInteropTurboModule keeps the existing RCT_EXPORT methods (e.g. `install`)
+// dispatchable without requiring a codegen spec, so this remains a drop-in
+// change that also works on the old architecture.
+- (std::shared_ptr<react::TurboModule>)getTurboModule:(const react::ObjCTurboModule::InitParams &)params
+{
+    return std::make_shared<react::ObjCInteropTurboModule>(params);
+}
+
+- (void)installJSIBindingsWithRuntime:(jsi::Runtime &)runtime
+                          callInvoker:(const std::shared_ptr<react::CallInvoker> &)callInvoker
+{
+    askarTurboModuleUtility::registerTurboModule(runtime, callInvoker);
+}
+
 RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(install)
 {
+    // New Architecture: the JSI bindings are installed via
+    // installJSIBindingsWithRuntime:callInvoker: when this TurboModule is
+    // created, so there is nothing to do here.
+    //
+    // Old Architecture (legacy bridge present): install using the bridge
+    // runtime so this keeps working for non-bridgeless apps.
     RCTBridge* bridge = [RCTBridge currentBridge];
     RCTCxxBridge* cxxBridge = (RCTCxxBridge*)bridge;
-    if (cxxBridge == nil) {
-        return @false;
+    if (cxxBridge != nil) {
+        jsi::Runtime* jsiRuntime = (jsi::Runtime*) cxxBridge.runtime;
+        if (jsiRuntime != nil) {
+            askarTurboModuleUtility::registerTurboModule(*jsiRuntime, bridge.jsCallInvoker);
+        }
     }
-    
-    jsi::Runtime* jsiRuntime = (jsi::Runtime*) cxxBridge.runtime;
-    if (jsiRuntime == nil) {
-        return @false;
-    }
-    
-    auto callInvoker = bridge.jsCallInvoker;
-    askarTurboModuleUtility::registerTurboModule(*jsiRuntime, callInvoker);
     return @true;
 }
 


### PR DESCRIPTION
On React Native 0.84+ with the New Architecture enabled, apps run in bridgeless mode and the legacy bridge is compiled out (`RCT_REMOVE_LEGACY_ARCH=1`). The native install() relied on APIs that no longer exist there, throwing `Error: Unable to install the turboModule: askar` at startup on new-arch / bridgeless apps.

